### PR TITLE
update to include gene in gff and unique exon names per gene

### DIFF
--- a/exonerate_protein_prediction.py
+++ b/exonerate_protein_prediction.py
@@ -220,6 +220,7 @@ for seq in blast_d:
                 if str(c) == '1':
                     gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(c)+';Parent=seq'+str(n)+'\n')
                     gene_start = gff_start
+                    gene_end = gff_end
                 else:
                     gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(c)+';Parent=seq'+str(n)+'\n')
                     gene_end = gff_end
@@ -227,13 +228,17 @@ for seq in blast_d:
                 gff_start = str(blast_d[seq][2]-s)
                 gff_end = str(blast_d[seq][2]-extract_d[s])
                 if str(c) == '1':
-                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(len(extract_starts)-c+1)+';Parent=seq'+seq'+str(n)+'\n')
+                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_end+'\t'+gff_start+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(len(extract_starts)-c+1)+';Parent=seq'+seq'+str(n)+'\n')
                     gene_start = gff_start
+                    gene_end = gff_end
                 else:
-                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(len(extract_starts)-c+1)+';Parent=seq'+seq'+str(n)+'\n')
+                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_end+'\t'+gff_start+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(len(extract_starts)-c+1)+';Parent=seq'+seq'+str(n)+'\n')
                     gene_end = gff_end
             c += 1
-        gffout.write(blast_d[seq][0]+'\t.\tgene\t'+str(gene_start)+'\t'+str(gene_end)+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'\n')
+        if blast_d[seq][3] == '+':
+            gffout.write(blast_d[seq][0]+'\t.\tgene\t'+str(gene_start)+'\t'+str(gene_end)+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'\n')
+        else:
+            gffout.write(blast_d[seq][0]+'\t.\tgene\t'+str(gene_end)+'\t'+str(gene_start)+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'\n')
         out.write('>seq'+str(n)+'.'+seq+'_'+blast_d[seq][0]+'\n'+sequence+'\n')
         # ouput to gff fileseq
         n += 1

--- a/exonerate_protein_prediction.py
+++ b/exonerate_protein_prediction.py
@@ -209,18 +209,31 @@ for seq in blast_d:
             extract_starts.append(extract_start)
         extract_starts.sort()
         c = 1
+        gene_start = 1
+        gene_end = 1
         for s in extract_starts:
             sequence += homology_d[seq][s-1:extract_d[s]]
             # output gff annotation
             if blast_d[seq][3] == '+':
                 gff_start = str(blast_d[seq][1]+s)
                 gff_end = str(blast_d[seq][1]+extract_d[s])
-                gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+';Exon='+str(c)+'\n')
+                if str(c) == '1':
+                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(c)+';Parent=seq'+str(n)+'\n')
+                    gene_start = gff_start
+                else:
+                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(c)+';Parent=seq'+str(n)+'\n')
+                    gene_end = gff_end
             else:
                 gff_start = str(blast_d[seq][2]-s)
                 gff_end = str(blast_d[seq][2]-extract_d[s])
-                gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+';Exon='+str(len(extract_starts)-c+1)+'\n')
+                if str(c) == '1':
+                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(len(extract_starts)-c+1)+';Parent=seq'+seq'+str(n)+'\n')
+                    gene_start = gff_start
+                else:
+                    gffout.write(blast_d[seq][0]+'\t.\texon\t'+gff_start+'\t'+gff_end+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'_exon'+str(len(extract_starts)-c+1)+';Parent=seq'+seq'+str(n)+'\n')
+                    gene_end = gff_end
             c += 1
+        gffout.write(blast_d[seq][0]+'\t.\tgene\t'+str(gene_start)+'\t'+str(gene_end)+'\t.\t'+blast_d[seq][3]+'\t.\tID=seq'+str(n)+'\n')
         out.write('>seq'+str(n)+'.'+seq+'_'+blast_d[seq][0]+'\n'+sequence+'\n')
         # ouput to gff fileseq
         n += 1


### PR DESCRIPTION
The GFF file wasn't being validated (it still isn't without a 2nd fix) with the original output.

I added a GENE section which covers the start of the first exon and the end of the final exon for each set.

I also changed the ID and PARENT tags so that GENE is now the parent, and each EXON per GENE is uniquely named to that GENE. 

The other thing that stops the GFF being valid is that the start and stop positions per exon are often in reverse, and the exon order itself are backwards (e.g. 4, 3, 2, 1).

I fixed that for now by using genometools like this: gt gff3 -tidy -retainids -o genome.fixed.gff genome.fasta.gff

Then the gff is valid enough that other gene predictions programs will read it and not complain about order and lacking a proper parent and unique exons names. 
